### PR TITLE
Enable start script to serve mock extension files on metro

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "lint": "eslint .",
-    "start": "react-native start",
+    "start": "npx react-native start --sourceExts mock.ts,js,json,ts,tsx --reset-cache",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
closes #25 