### PR TITLE
Use StyleSheet.create throughout app - no longer using an external frontend library

### DIFF
--- a/src/components/Camera/index.tsx
+++ b/src/components/Camera/index.tsx
@@ -3,6 +3,8 @@ import {View, Touchable, Image} from 'src/components/common';
 import {Camera as CameraView} from 'react-native-vision-camera';
 import testIds from 'src/test-ids';
 
+import Styles from './styles';
+
 type Props = {
   device: any;
   photo: string | null;
@@ -15,32 +17,20 @@ export const Camera = React.forwardRef<CameraView, Props>(
   (props: Props, ref: React.Ref<CameraView>): JSX.Element => {
     const [isCameraReady, setIsCameraReady] = React.useState<boolean>(false);
     const {device, photo, shutterSize, onTakePhoto, removePhoto} = props;
+    const shutterStyle = React.useRef({
+      backgroundColor: photo ? 'gray' : 'red',
+      height: shutterSize,
+      width: shutterSize,
+      borderRadius: shutterSize / 2,
+    });
     return (
-      <View
-        style={{
-          flex: 1,
-          justifyContent: 'space-around',
-          paddingBottom: shutterSize,
-        }}>
-        <View
-          style={{
-            flex: 0.88,
-            width: '95%',
-            borderRadius: 12,
-            overflow: 'hidden',
-            alignSelf: 'center',
-          }}>
+      <View style={[Styles.container, {paddingBottom: shutterSize}]}>
+        <View style={Styles.innerContainer}>
           {photo && (
             <Image
               testID={testIds.page.camera.picture}
               source={{uri: photo}}
-              style={{
-                position: 'absolute',
-                top: 0,
-                right: 0,
-                bottom: 0,
-                left: 0,
-              }}
+              style={Styles.absolute}
             />
           )}
           {!photo && (
@@ -48,13 +38,7 @@ export const Camera = React.forwardRef<CameraView, Props>(
               ref={ref}
               photo
               testID={testIds.page.camera.cameraView}
-              style={{
-                position: 'absolute',
-                top: 0,
-                right: 0,
-                bottom: 0,
-                left: 0,
-              }}
+              style={Styles.absolute}
               device={device}
               isActive
               onInitialized={() => {
@@ -71,13 +55,7 @@ export const Camera = React.forwardRef<CameraView, Props>(
               : testIds.page.camera.shutter
           }
           onPress={photo ? removePhoto : onTakePhoto}
-          style={{
-            backgroundColor: photo ? 'gray' : 'red',
-            height: shutterSize,
-            width: shutterSize,
-            alignSelf: 'center',
-            borderRadius: shutterSize / 2,
-          }}></Touchable>
+          style={[Styles.shutter, shutterStyle.current]}></Touchable>
       </View>
     );
   },

--- a/src/components/Camera/styles.ts
+++ b/src/components/Camera/styles.ts
@@ -1,0 +1,23 @@
+import {StyleSheet} from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'space-around',
+  },
+  innerContainer: {
+    flex: 0.88,
+    width: '95%',
+    borderRadius: 12,
+    overflow: 'hidden',
+    alignSelf: 'center',
+  },
+  absolute: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+  },
+  shutter: {alignSelf: 'center'},
+});

--- a/src/components/SignIn/SignInForm/index.tsx
+++ b/src/components/SignIn/SignInForm/index.tsx
@@ -11,6 +11,8 @@ import {
   Touchable,
 } from 'src/components/common';
 
+import Styles from './styles';
+
 type SignInFormProps = {
   username: string;
   setUsername: (username: string) => void;
@@ -62,7 +64,7 @@ export const SignInForm = (props: SignInFormProps): JSX.Element | null => {
       />
       <GoogleSigninButton
         testID={testIds.page.signin.googleSignInButton}
-        style={{width: 192, height: 48}}
+        style={Styles.googleBtn}
         size={GoogleSigninButton.Size.Wide}
         color={GoogleSigninButton.Color.Dark}
         onPress={googleSignIn}

--- a/src/components/SignIn/SignInForm/styles.ts
+++ b/src/components/SignIn/SignInForm/styles.ts
@@ -1,0 +1,5 @@
+import {StyleSheet} from 'react-native';
+
+export default StyleSheet.create({
+  googleBtn: {width: 192, height: 48},
+});


### PR DESCRIPTION
Many enabling libraries exist to make styling easier in react native. However, there will always be the risk of libraries losing maintainability.

Advantages such as easier dark mode implementation, dynamic font sizing depending on screen dimensions and the like can be manually implemented using StyleSheet.create, which is the default API provided by react native. 

closes #3 